### PR TITLE
Add VCF annotation trimming to workflow

### DIFF
--- a/poll_process.py
+++ b/poll_process.py
@@ -8,6 +8,7 @@ import botocore
 import errno
 from subprocess import call, check_output
 import time
+import vcf_trimmer
 
 def silentremove(filename):
     try:
@@ -87,6 +88,13 @@ def process_vcf(UDN_ID, sequence_core_alias, FileBucket, FileKey, Sample_ID, upl
 
     if change_log_file_size == 0:
         print("[DEBUG] Error swapping identifiers in file. Changelog file is empty. {}|{}|{}|{}|{}|{}".format(UDN_ID,FileBucket,FileKey,Sample_ID,upload_file_name,file_type),flush=True)
+
+    os.rename('/scratch/{}'.format(upload_file_name), '/scratch/{}.bak'.format(upload_file_name))
+    try:
+        vcf_trimmer.trim('/scratch/{}.bak'.format(upload_file_name), '/scratch/{}'.format(upload_file_name))
+    except:
+        print("[DEBUG] Error trimming VCF annotations. {}|{}|{}|{}|{}|{}".format(UDN_ID, FileBucket, FileKey, Sample_ID, upload_file_name, file_type), flush=True)
+        os.rename('/scratch/{}.bak'.format(upload_file_name), '/scratch/{}'.format(upload_file_name))
 
     try:
         print("[DEBUG] Attempting to upload file " + upload_file_name + " via Aspera - subasp@upload.ncbi.nlm.nih.gov:uploads:" + VCF_LOCATION_CODE, flush=True)

--- a/vcf_trimmer.py
+++ b/vcf_trimmer.py
@@ -1,0 +1,57 @@
+import re
+
+# only these INFO annotations will be retained
+WHITELISTED_ANNOTATIONS = {
+    'AC', 'AF', 'AN', 'BaseQRankSum', 'ClippingRankSum', 'DP', 'FS', 'GQ_MEAN',
+    'GQ_STDDEV', 'InbreedingCoeff', 'MQ', 'MQ0', 'MQRankSum', 'MS', 'NCC',
+    'NEGATIVE_TRAIN_SITE', 'P', 'POSITIVE_TRAIN_SITE', 'QD', 'ReadPosRankSum',
+    'SOR', 'VQSLOD', 'culprit'
+}
+
+
+def process_header(line):
+    """Returns the header line unchanged, unless it's an INFO header for an
+    annotation that isn't in the whitelist.
+    """
+
+    match = re.match(r'##INFO=<ID=([^,]+)', line)
+    if not match:
+        return line
+
+    info_name = match.group(1)
+    if info_name in WHITELISTED_ANNOTATIONS:
+        return line
+
+    return None  # will not be output to file
+
+
+def process_body(line):
+    """Retains only whitelisted INFO annotations in each record."""
+
+    fields = line.split('\t')  # preserves newline
+    infos = fields[7].split(';')
+
+    whitelisted = [
+        info for info in infos
+        if any(
+            info.startswith(x + '=') or info == x
+            for x in WHITELISTED_ANNOTATIONS
+        )
+    ]
+
+    fields[7] = ';'.join(whitelisted)
+    return '\t'.join(fields)
+
+
+def trim(from_file, to_file):
+    """Trims unwanted INFO annotations from a VCF file, including the header."""
+
+    with open(from_file) as f_input, open(to_file, 'w') as f_output:
+        for line in f_input:
+            if line.startswith('#'):
+                result = process_header(line)
+            else:
+                result = process_body(line)
+
+            if result is not None:
+                f_output.write(result)


### PR DESCRIPTION
Retains only specified INFO annotations in the header and records of a VCF file. If any exceptions are raised during filtering, the original VCF is restored and the upload script continues.